### PR TITLE
gitlint: How to fix a gitlint warning

### DIFF
--- a/.github/actions/gitlint/action.yml
+++ b/.github/actions/gitlint/action.yml
@@ -32,8 +32,9 @@ runs:
       git fetch origin +refs/heads/main:refs/remotes/origin/main && \
       git fetch origin +refs/pull/${{ inputs.pr-number }}/head && \
       if ! gitlint --commits origin/main..HEAD; then \
-        echo "WARNING: Your commit message does not follow the required format."
-        echo "To fix your commit message, run:"
+        echo "\nWARNING: Your commit message does not follow the required format."
+        echo "Formatting rules: https://eclipse-score.github.io/score/process/guidance/git/index.html"
+        echo "\nTo fix your commit message, run:"
         echo " git commit --amend"
         echo "Then update your commit (fix gitlint warnings). Finally, force-push:"
         echo " git push --force-with-lease"


### PR DESCRIPTION
When a bad formatted commit is pushed, gitlint will provide information on how to fix the commit message using git.