### PR TITLE
git: Update gitlint error message

### DIFF
--- a/.github/actions/gitlint/action.yml
+++ b/.github/actions/gitlint/action.yml
@@ -29,11 +29,11 @@ runs:
     - -c
     - |
       git config --global --add safe.directory /github/workspace && \
-      git fetch origin +refs/heads/main:refs/remotes/origin/main && \
+      git fetch origin +refs/heads/${{ inputs.base-branch }}:refs/remotes/origin/${{ inputs.base-branch }} && \
       git fetch origin +refs/pull/${{ inputs.pr-number }}/head && \
-      if ! gitlint --commits origin/main..HEAD; then \
+      if ! gitlint --commits ${{ inputs.base-branch }}..HEAD; then \
         echo -e "\nWARNING: Your commit message does not follow the required format." && \
-        echo "Formatting rules: https://eclipse-score.github.io/score/process/guidance/git/index.html" && \
+        echo "Formatting rules: https://eclipse-score.github.io/score/main/contribute/general/git.html" && \
         echo -e "To fix your commit message, run:\n" && \
         echo " git commit --amend" && \
         echo "Then update your commit (fix gitlint warnings). Finally, force-push:" && \

--- a/.gitlint
+++ b/.gitlint
@@ -16,7 +16,7 @@
 #   B7: body-changed-file-mention (disabled)
 #
 # See http://jorisroovers.github.io/gitlint/rules/ for a full description of the rules.
-# See https://eclipse-score.github.io/score/process/guidance/git/index.html for our commit message guidelines.
+# See https://eclipse-score.github.io/score/main/contribute/general/git.html for our commit message guidelines.
 
 # Ignore some default rules and enable regex style searching
 [general]


### PR DESCRIPTION
Use correct link to docs in gitlint error message. Use base-branch input instead of hardcoded main.